### PR TITLE
Fix path to kernel build dir.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-KDIR ?= /lib/modules/${kernelver}/build
+KVERSION ?= `uname -r`
+KDIR ?= /lib/modules/${KVERSION}/build
 
 default:
 	$(MAKE) -C $(KDIR) M=$$PWD

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-KDIR ?= /lib/modules/`uname -r`/build
+KDIR ?= /lib/modules/${kernelver}/build
 
 default:
 	$(MAKE) -C $(KDIR) M=$$PWD

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-KVERSION ?= `uname -r`
-KDIR ?= /lib/modules/${KVERSION}/build
+KVERSION := `uname -r`
+KDIR := /lib/modules/${KVERSION}/build
 
 default:
 	$(MAKE) -C $(KDIR) M=$$PWD

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,6 @@
 PACKAGE_NAME="new-lg4ff"
 PACKAGE_VERSION="0.1"
-MAKE[0]="make"
+MAKE[0]="make KVERSION=$kernelver"
 CLEAN="make clean"
 BUILT_MODULE_NAME[0]="hid-logitech-new"
 DEST_MODULE_NAME[0]="hid-logitech"


### PR DESCRIPTION
Don't use version of the currently running kernel, but the
version the module is build for (when buildung for multiple
installed kernels or during kernel upgrades).

@parkerlreed 