### PR TITLE
Fix types for 32bits systems

### DIFF
--- a/hid-lg4ff.c
+++ b/hid-lg4ff.c
@@ -104,7 +104,7 @@ struct lg4ff_effect_state {
 };
 
 struct lg4ff_effect_parameters {
-	s64 level;
+	int level;
 	int d1;
 	int d2;
 	int k1;
@@ -152,7 +152,7 @@ struct lg4ff_device_entry {
 	struct hrtimer hrtimer;
 	struct lg4ff_slot slots[4];
 	struct lg4ff_effect_state states[LG4FF_MAX_EFFECTS];
-	u64 peak_ffb_level;
+	unsigned peak_ffb_level;
 	int effects_used;
 #ifdef CONFIG_LEDS_CLASS
 	int has_leds;
@@ -529,8 +529,8 @@ void lg4ff_update_slot(struct lg4ff_slot *slot, struct lg4ff_effect_parameters *
 static __always_inline int lg4ff_calculate_constant(struct lg4ff_effect_state *state)
 {
 	int level_sign;
-	s64 level = state->effect.u.constant.level;
-	s64 d, t;
+	int level = state->effect.u.constant.level;
+	int d, t;
 
 	if (state->time_playing < state->envelope->attack_length) {
 		level_sign = level < 0 ? -1 : 1;
@@ -552,8 +552,8 @@ static __always_inline int lg4ff_calculate_ramp(struct lg4ff_effect_state *state
 {
 	struct ff_ramp_effect *ramp = &state->effect.u.ramp;
 	int level_sign;
-	s64 level = S64_MAX;
-	s64 d, t;
+	int level = INT_MAX;
+	int d, t;
 
 	if (state->time_playing < state->envelope->attack_length) {
 		level = ramp->start_level;
@@ -578,10 +578,10 @@ static __always_inline int lg4ff_calculate_ramp(struct lg4ff_effect_state *state
 static __always_inline int lg4ff_calculate_periodic(struct lg4ff_effect_state *state)
 {
 	struct ff_periodic_effect *periodic = &state->effect.u.periodic;
-	s64 magnitude = periodic->magnitude;
+	int magnitude = periodic->magnitude;
 	int magnitude_sign = magnitude < 0 ? -1 : 1;
-	s64 level = periodic->offset;
-	s64 d, t;
+	int level = periodic->offset;
+	int d, t;
 
 	if (state->time_playing < state->envelope->attack_length) {
 		d = magnitude - magnitude_sign * state->envelope->attack_level;
@@ -717,10 +717,10 @@ static __always_inline int lg4ff_timer(struct lg4ff_device_entry *entry)
 	struct lg4ff_slot *slot;
 	struct lg4ff_effect_state *state;
 	struct lg4ff_effect_parameters parameters[4];
-	s64 gain;
 	unsigned long jiffies_now = jiffies;
 	unsigned long now = JIFFIES2MS(jiffies_now);
 	unsigned long flags;
+	unsigned gain;
 	int current_period;
 	int count;
 	int effect_id;
@@ -745,7 +745,7 @@ static __always_inline int lg4ff_timer(struct lg4ff_device_entry *entry)
 
 	memset(parameters, 0, sizeof(parameters));
 
-	gain = (s64)entry->wdata.master_gain * entry->wdata.gain / 0xffff;
+	gain = (unsigned)entry->wdata.master_gain * entry->wdata.gain / 0xffff;
 
 	spin_lock_irqsave(&entry->timer_lock, flags);
 
@@ -807,16 +807,16 @@ static __always_inline int lg4ff_timer(struct lg4ff_device_entry *entry)
 
 	spin_unlock_irqrestore(&entry->timer_lock, flags);
 
-	parameters[0].level = (s64)parameters[0].level * gain / 0xffff;
-	parameters[1].clip = (s64)parameters[1].clip * spring_level / 100;
-	parameters[2].clip = (s64)parameters[2].clip * damper_level / 100;
-	parameters[3].clip = (s64)parameters[3].clip * friction_level / 100;
+	parameters[0].level = (int)parameters[0].level * (int)gain / 0xffff;
+	parameters[1].clip = parameters[1].clip * spring_level / 100;
+	parameters[2].clip = parameters[2].clip * damper_level / 100;
+	parameters[3].clip = parameters[3].clip * friction_level / 100;
 
 	ffb_level = abs(parameters[0].level);
 	for (i = 1; i < 4; i++) {
-		parameters[i].k1 = (s64)parameters[i].k1 * gain / 0xffff;
-		parameters[i].k2 = (s64)parameters[i].k2 * gain / 0xffff;
-		parameters[i].clip = (s64)parameters[i].clip * gain / 0xffff;
+		parameters[i].k1 = parameters[i].k1 * gain / 0xffff;
+		parameters[i].k2 = parameters[i].k2 * gain / 0xffff;
+		parameters[i].clip = parameters[i].clip * gain / 0xffff;
 		ffb_level += parameters[i].clip * 0x7fff / 0xffff;
 	}
 	if (ffb_level > entry->peak_ffb_level) {
@@ -1839,7 +1839,7 @@ static ssize_t lg4ff_peak_ffb_level_show(struct device *dev, struct device_attri
 		return -EINVAL;
 	}
 
-	count = scnprintf(buf, PAGE_SIZE, "%llu\n", entry->peak_ffb_level);
+	count = scnprintf(buf, PAGE_SIZE, "%u\n", entry->peak_ffb_level);
 
 	return count;
 }


### PR DESCRIPTION
Ensure that 64bits variables are used where is needed even on 32bits systems. This should fix #47.