### PR TITLE
add 'play_on_upload' sysfs toggle for BeamNG.drive 'Fast' update type

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ get and set property values.
 This entry already existed. It has been extended, setting the value to 2
 combines the clutch and gas pedals in the same axis.
 
+### play_on_upload
+
+BeamNG.drive has a "Fast" update type that skips play effect events entirely
+and expects the wheel to just play effects on upload. Set this to 1 to play
+effects on upload for applications with this behavior.
+
 ### gain
 
 Get/set the global FF gain (0-65535). This property is independent of the gain

--- a/hid-lg4ff.c
+++ b/hid-lg4ff.c
@@ -132,6 +132,7 @@ struct lg4ff_slot {
 struct lg4ff_wheel_data {
 	const u32 product_id;
 	u16 combine;
+	u16 play_on_upload;
 	u16 range;
 	u16 autocenter;
 	u16 master_gain;
@@ -1001,6 +1002,7 @@ static void lg4ff_stop_effects(struct lg4ff_device_entry *entry)
 	lg4ff_send_cmd(entry, cmd);
 }
 
+static int lg4ff_play_effect(struct input_dev *dev, int effect_id, int value);
 static int lg4ff_upload_effect(struct input_dev *dev, struct ff_effect *effect, struct ff_effect *old)
 {
 	struct hid_device *hid = input_get_drvdata(dev);
@@ -1034,6 +1036,10 @@ static int lg4ff_upload_effect(struct input_dev *dev, struct ff_effect *effect, 
 	}
 
 	spin_unlock_irqrestore(&entry->timer_lock, flags);
+
+	if (entry->wdata.play_on_upload) {
+		lg4ff_play_effect(dev, effect->id, 1);
+	}
 
 	return 0;
 }
@@ -1221,6 +1227,7 @@ static void lg4ff_init_wheel_data(struct lg4ff_wheel_data * const wdata, const s
 		struct lg4ff_wheel_data t_wdata =  { .product_id = wheel->product_id,
 						     .real_product_id = real_product_id,
 						     .combine = 0,
+						     .play_on_upload = 0,
 						     .min_range = wheel->min_range,
 						     .max_range = wheel->max_range,
 						     .set_range = wheel->set_range,
@@ -1707,6 +1714,41 @@ static ssize_t lg4ff_combine_store(struct device *dev, struct device_attribute *
 	return count;
 }
 static DEVICE_ATTR(combine_pedals, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH, lg4ff_combine_show, lg4ff_combine_store);
+
+static ssize_t lg4ff_play_on_upload_show(struct device *dev, struct device_attribute *attr,
+				char *buf)
+{
+	struct hid_device *hid = to_hid_device(dev);
+	struct lg4ff_device_entry *entry;
+	size_t count;
+
+	entry = lg4ff_get_device_entry(hid);
+	if (entry == NULL) {
+		return -EINVAL;
+	}
+
+	count = scnprintf(buf, PAGE_SIZE, "%u\n", entry->wdata.play_on_upload);
+	return count;
+}
+
+static ssize_t lg4ff_play_on_upload_store(struct device *dev, struct device_attribute *attr,
+				 const char *buf, size_t count)
+{
+	struct hid_device *hid = to_hid_device(dev);
+	struct lg4ff_device_entry *entry = lg4ff_get_device_entry(hid);
+	u16 play_on_upload;
+
+	if (entry == NULL) {
+		return -EINVAL;
+	}
+
+	play_on_upload = simple_strtoul(buf, NULL, 10);
+
+	entry->wdata.play_on_upload = play_on_upload ? 1 : 0;
+
+	return count;
+}
+static DEVICE_ATTR(play_on_upload, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH, lg4ff_play_on_upload_show, lg4ff_play_on_upload_store);
 
 /* Export the currently set range of the wheel */
 static ssize_t lg4ff_range_show(struct device *dev, struct device_attribute *attr,
@@ -2362,6 +2404,9 @@ int lg4ff_init(struct hid_device *hid)
 	error = device_create_file(&hid->dev, &dev_attr_combine_pedals);
 	if (error)
 		hid_warn(hid, "Unable to create sysfs interface for \"combine\", errno %d\n", error);
+	error = device_create_file(&hid->dev, &dev_attr_play_on_upload);
+	if (error)
+		hid_warn(hid, "Unable to create sysfs interface for \"play_on_upload\", errno %d\n", error);
 	error = device_create_file(&hid->dev, &dev_attr_range);
 	if (error)
 		hid_warn(hid, "Unable to create sysfs interface for \"range\", errno %d\n", error);
@@ -2466,6 +2511,7 @@ int lg4ff_deinit(struct hid_device *hid)
 	}
 
 	device_remove_file(&hid->dev, &dev_attr_combine_pedals);
+	device_remove_file(&hid->dev, &dev_attr_play_on_upload);
 	device_remove_file(&hid->dev, &dev_attr_range);
 
 	if (test_bit(FF_CONSTANT, dev->ffbit)) {


### PR DESCRIPTION
Not sure if there are applications other than BeamNG.drive with this kind of expectation, are there other wheel drivers out there that just play effects on upload?