### PR TITLE
fake friction effect using damper effect

### DIFF
--- a/hid-lg4ff.c
+++ b/hid-lg4ff.c
@@ -459,7 +459,7 @@ static struct lg4ff_device_entry *lg4ff_get_device_entry(struct hid_device *hid)
 	return entry;
 }
 
-void lg4ff_send_cmd_with_id(struct lg4ff_device_entry *entry, u8 *cmd, u8 id) {
+static void lg4ff_send_cmd_with_id(struct lg4ff_device_entry *entry, u8 *cmd, u8 id) {
 	unsigned long flags;
 	s32 *value = entry->report->field[0]->value;
 
@@ -477,7 +477,7 @@ void lg4ff_send_cmd_with_id(struct lg4ff_device_entry *entry, u8 *cmd, u8 id) {
 	DEBUG("send_cmd: %02X %02X %02X %02X %02X %02X %02X %02X\n", id, cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5], cmd[6]);
 }
 
-void lg4ff_send_cmd(struct lg4ff_device_entry *entry, u8 *cmd)
+static void lg4ff_send_cmd(struct lg4ff_device_entry *entry, u8 *cmd)
 {
 	unsigned long flags;
 	s32 *value = entry->report->field[0]->value;
@@ -495,7 +495,7 @@ void lg4ff_send_cmd(struct lg4ff_device_entry *entry, u8 *cmd)
 	DEBUG("send_cmd: %02X %02X %02X %02X %02X %02X %02X", cmd[0], cmd[1], cmd[2], cmd[3], cmd[4], cmd[5], cmd[6]);
 }
 
-void lg4ff_update_slot(struct lg4ff_slot *slot, struct lg4ff_effect_parameters *parameters)
+static void lg4ff_update_slot(struct lg4ff_slot *slot, struct lg4ff_effect_parameters *parameters)
 {
 	u8 original_cmd[7];
 	int d1;


### PR DESCRIPTION
Dirt Rally 2.0 relies on the 'friction' effect to feel good, and is not able to fall back on 'damper' if the wheel does not expose FF_FRICTION.

The g923 fails spectacularly when sent a 'friction' effect (#86).

This patch replaces the 'friction' effect with a 'damper' effect of same intensity. This is what the Logitech Windows driver does for this model.
Because this wheel also ignores the Clip parameter, two 'damper' effects actually add up somewhat coherently ? I'm assuming no game use both 'friction' and 'damper'.

This should probably be enabled on other similar models as well, but I do not know which